### PR TITLE
Make middle name optional (PHP and JS)

### DIFF
--- a/JavaScript/open_science_identity.js
+++ b/JavaScript/open_science_identity.js
@@ -65,9 +65,7 @@ OpenScienceIdentity.prototype.valid = function() {
     if (! this.cleanFirstName()) {
         this.bad_attributes.push('first name');
     }
-    if (! this.cleanMiddleName()) {
-        this.bad_attributes.push('middle name');
-    }
+    // No check for middle name because it's optional
     if (! this.cleanLastName()) {
         this.bad_attributes.push('last name');
     }

--- a/PHP/open_science_identity.php
+++ b/PHP/open_science_identity.php
@@ -70,9 +70,7 @@ class OpenScienceIdentity {
         if (empty($this->cleanFirstName())) {
             $this->bad_attributes[] = 'first name';
         }
-        if (empty($this->cleanMiddleName())) {
-            $this->bad_attributes[] = 'middle name';
-        }
+        // No check for middle name because it is an optional field.
         if (empty($this->cleanLastName())) {
             $this->bad_attributes[] = 'last name';
         }


### PR DESCRIPTION
The middle name field is allowed to be empty because some people don't have them.

This change will make it so that blank middle names will no longer fail in the validation step.

TODO: Update Perl and Ruby to do the same.