### PR TITLE
Return empty string on "blank" values (PHP, JS); test cleanup (PHP)

### DIFF
--- a/JavaScript/open_science_identity.js
+++ b/JavaScript/open_science_identity.js
@@ -161,7 +161,9 @@ let num_exp_inv = 0;
 
 // For every line, create a new identity and check that the result is valid.
 rd.on('line', function(line) {
-    console.log(line);
+    if (!line || line.startsWith('#')) {
+        return;
+    }
     let parts = line.split(',');
     let id = new OpenScienceIdentity(
         {

--- a/JavaScript/open_science_identity.js
+++ b/JavaScript/open_science_identity.js
@@ -105,6 +105,9 @@ OpenScienceIdentity.prototype.signatureKey = function() {
 };
 
 OpenScienceIdentity.prototype.plainAlpha = function(string) {
+    if (string === null || string.trim().length < 1) {
+        return '';
+    }
     let cleaned = transliterate.transliterate(string);
     cleaned = cleaned.toLowerCase();
     cleaned = cleaned.replace(/[^a-z0-9]+/g, '');

--- a/JavaScript/open_science_identity.js
+++ b/JavaScript/open_science_identity.js
@@ -146,7 +146,7 @@ const fs = require('fs'),
     readline = require('readline');
 
 let rd = readline.createInterface({
-    input: fs.createReadStream('../Ruby/names_db.csv'), //TODO: don't store this file in Ruby dir
+    input: fs.createReadStream('../test/names_db.csv'),
     console: false
 });
 

--- a/PHP/open_science_identity.php
+++ b/PHP/open_science_identity.php
@@ -113,6 +113,10 @@ class OpenScienceIdentity {
     }
 
     private function plainAlpha($string): String {
+        // If given a "blank" value, return the empty string.
+        if (is_null($string) || strlen(trim($string)) < 1) {
+            return "";
+        }
         // Convert $string to a lower-case, anglicized ASCII version of itself
         setlocale(LC_CTYPE, 'en_US.UTF8');
         // iconv is here used to change accented characters to unaccented ones

--- a/PHP/test.php
+++ b/PHP/test.php
@@ -18,6 +18,10 @@ $num_inv = $num_exp_inv = 0;
 $db_filepath = "../test/names_db.csv";
 if (($handle = fopen($db_filepath, "r")) !== FALSE) {
     while (($line = fgetcsv($handle, 1000, ",")) !== FALSE) {
+        // Ignore commented lines (Perl-style comments are used in the test file)
+        if (empty($line[0]) || strpos($line[0], '#') === 0) {
+            continue;
+        }
         list($gender, $first_name, $middle_name, $last_name, $birth_day, $city_of_birth, $sig) = $line;
         // Keep track of totals
         if ($sig === 'invalid') {


### PR DESCRIPTION
Changes:

* Change PHP and JS implementations to return an empty string on null/empty values passed to `plain_alpha` function

* Update filepath in JS implementation to use new test path (instead of relative to Ruby dir)

* Skip commented and blank lines when reading test csv file (PHP and JS)